### PR TITLE
Remove unused methods and improve Earthquake update handling

### DIFF
--- a/apps/backend/src/database/repositories/EarthquakeRepository.ts
+++ b/apps/backend/src/database/repositories/EarthquakeRepository.ts
@@ -9,9 +9,6 @@ const EARTHQUAKE_NOT_FOUND_ERROR = (id: number) =>
 export class EarthquakeRepository {
   private repository = AppDataSource.getRepository(Earthquake);
 
-  // Fetch all earthquake records
-  findAll = () => this.repository.find();
-
   // Fetch a single earthquake by ID
   findById = (id: number) => this.repository.findOneBy({ id });
 

--- a/apps/backend/src/graphql/resolvers.ts
+++ b/apps/backend/src/graphql/resolvers.ts
@@ -10,25 +10,15 @@ export const earthquakeResolvers = {
     earthquakes: async (_parent: unknown, args: GetEarthquakesInput) => {
       return earthquakeService.getAllEarthquakes(args);
     },
-    // earthquake: async (
-    //   _parent: unknown,
-    //   { id }: { id: number }
-    // ): Promise<Earthquake | null> => earthquakeService.getEarthquakeById(id),
   },
 
   Mutation: {
-    // addEarthquake: async (
-    //   _parent: unknown,
-    //   { location, magnitude, date }: Omit<Earthquake, 'id'>
-    // ): Promise<Earthquake> => {
-    //   const earthquake = {
-    //     location,
-    //     magnitude,
-    //     date: new Date(date),
-    //   };
-    //
-    //   return earthquakeService.addEarthquake(earthquake);
-    // },
+    addEarthquake: async (
+      _parent: unknown,
+      { data }: { data: EarthquakeData }
+    ): Promise<Earthquake> => {
+      return earthquakeService.addEarthquake(data);
+    },
     updateEarthquake: async (
       _parent: unknown,
       { id, data }: { id: number; data: EarthquakeData }

--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -17,11 +17,7 @@ export const typeDefs = gql`
   }
 
   type Mutation {
-    addEarthquake(
-      location: String!
-      magnitude: Float!
-      date: String!
-    ): Earthquake
+    addEarthquake(data: EarthquakeUpdateInput!): Earthquake
     updateEarthquake(id: ID!, data: EarthquakeUpdateInput!): Earthquake
     deleteEarthquake(id: ID!): String
   }

--- a/apps/backend/src/services/EarthquakeService.ts
+++ b/apps/backend/src/services/EarthquakeService.ts
@@ -25,19 +25,7 @@ export class EarthquakeService {
     return { data, success: true, total };
   }
 
-  async getEarthquakeById(id: number): Promise<Earthquake | null> {
-    return this.repository.findById(id);
-  }
-
-  async addEarthquake(
-    data: Omit<Earthquake, 'id' | 'createdAt' | 'updatedAt'>
-  ): Promise<Earthquake> {
-    return this.repository.create(data);
-  }
-
   async updateEarthquake(id: number, data: EarthquakeData) {
-    console.log('updateEarthquake service', { id, data });
-
     return this.repository.update(id, data);
   }
 

--- a/apps/backend/src/services/EarthquakeService.ts
+++ b/apps/backend/src/services/EarthquakeService.ts
@@ -25,6 +25,10 @@ export class EarthquakeService {
     return { data, success: true, total };
   }
 
+  async addEarthquake(data: EarthquakeData): Promise<Earthquake> {
+    return this.repository.create(data);
+  }
+
   async updateEarthquake(id: number, data: EarthquakeData) {
     return this.repository.update(id, data);
   }

--- a/apps/frontend/app/graphql/mutations.ts
+++ b/apps/frontend/app/graphql/mutations.ts
@@ -1,6 +1,16 @@
 import { gql } from '@apollo/client';
 import { EARTHQUAKE_FRAGMENT } from 'graphql-common/src/fragments';
 
+export const ADD_EARTHQUAKE = gql`
+  mutation AddEarthquake($data: EarthquakeUpdateInput!) {
+    addEarthquake(data: $data) {
+      ...EarthquakeFields
+      __typename
+    }
+  }
+  ${EARTHQUAKE_FRAGMENT}
+`;
+
 export const UPDATE_EARTHQUAKE = gql`
   mutation UpdateEarthquake($id: ID!, $data: EarthquakeUpdateInput!) {
     updateEarthquake(id: $id, data: $data) {

--- a/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateForm.tsx
+++ b/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateForm.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Button, Form, Modal } from 'antd';
-import { ProFormText, ProFormDigit, ProForm } from '@ant-design/pro-components';
+import {
+  ProFormText,
+  ProFormDigit,
+  ProForm,
+  ProFormDateTimePicker,
+} from '@ant-design/pro-components';
 import { UpdateFormProps, UpdateFormValues } from './UpdateFormProps';
 
 export const UpdateForm: React.FC<UpdateFormProps> = ({
@@ -23,6 +28,17 @@ export const UpdateForm: React.FC<UpdateFormProps> = ({
     form.submit();
   }, [form]);
 
+  useEffect(() => {
+    if (values) {
+      form.setFieldsValue({
+        ...values,
+        date: values.date ? new Date(Number(values.date)) : undefined,
+      });
+    } else {
+      form.resetFields();
+    }
+  }, [form, values]);
+
   return (
     <Modal
       destroyOnClose
@@ -30,9 +46,13 @@ export const UpdateForm: React.FC<UpdateFormProps> = ({
       open={props.updateModalOpen}
       onCancel={cancelHandler}
       footer={[
-        <Button key="delete" danger onClick={handleDelete}>
-          Delete
-        </Button>,
+        ...(values?.id
+          ? [
+              <Button key="delete" danger onClick={handleDelete}>
+                Delete
+              </Button>,
+            ]
+          : []),
         <Button key="cancel" onClick={cancelHandler}>
           Cancel
         </Button>,
@@ -41,7 +61,11 @@ export const UpdateForm: React.FC<UpdateFormProps> = ({
         </Button>,
       ]}
     >
-      <ProForm<UpdateFormValues> onFinish={onSubmit} initialValues={values} submitter={false} >
+      <ProForm<UpdateFormValues>
+        onFinish={onSubmit}
+        submitter={false}
+        form={form}
+      >
         <ProFormText
           name="location"
           label="Location"
@@ -50,9 +74,19 @@ export const UpdateForm: React.FC<UpdateFormProps> = ({
         <ProFormDigit
           name="magnitude"
           label="Magnitude"
-          rules={[{ required: true, message: 'Please enter the magnitude' }]}
+          rules={[
+            { required: true, message: 'Please enter the magnitude' },
+            {
+              validator: (_: unknown, value: number) =>
+                value > 0
+                  ? Promise.resolve()
+                  : Promise.reject(
+                      new Error('Magnitude must be a positive number')
+                    ),
+            },
+          ]}
         />
-        <ProFormText
+        <ProFormDateTimePicker
           name="date"
           label="Date"
           rules={[{ required: true, message: 'Please select the date' }]}

--- a/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateForm.tsx
+++ b/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateForm.tsx
@@ -41,7 +41,7 @@ export const UpdateForm: React.FC<UpdateFormProps> = ({
         </Button>,
       ]}
     >
-      <ProForm<UpdateFormValues> onFinish={onSubmit} initialValues={values}>
+      <ProForm<UpdateFormValues> onFinish={onSubmit} initialValues={values} submitter={false} >
         <ProFormText
           name="location"
           label="Location"

--- a/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateFormProps.tsx
+++ b/apps/frontend/components/EarthquakeCatalog/components/UpdateForm/UpdateFormProps.tsx
@@ -7,5 +7,5 @@ export type UpdateFormProps = {
   onSubmit: (values: UpdateFormValues) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
   updateModalOpen: boolean;
-  values: UpdateFormValues;
+  values: UpdateFormValues | undefined;
 };


### PR DESCRIPTION
Removed unused methods from EarthquakeService and EarthquakeRepository to simplify the codebase and eliminate redundancy. 

Additionally, updated the UpdateForm in the front-end to disable the default form submission behavior, improving customization and consistency.